### PR TITLE
New version of tock-react-kit standalone

### DIFF
--- a/fr/index.html
+++ b/fr/index.html
@@ -7,14 +7,9 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no"/>
     <link rel="stylesheet" href="assets/css/main.css"/>
-    <script crossorigin src="https://unpkg.com/react@16/umd/react.development.js"></script>
-    <script crossorigin src="https://unpkg.com/react-dom@16/umd/react-dom.development.js"></script>
-    <script crossorigin src="https://unpkg.com/@emotion/core@10/dist/core.umd.min.js"></script>
-    <script crossorigin src="https://unpkg.com/@emotion/styled@10/dist/styled.umd.min.js"></script>
-    <script crossorigin src="https://unpkg.com/emotion-theming@10/dist/emotion-theming.umd.min.js"></script>
     <script
             crossorigin
-            src="https://unpkg.com/tock-react-kit@latest/build/tock-react-kit.umd.js"
+            src="https://unpkg.com/tock-react-kit@latest/build/tock-react-kit-standalone.umd.js"
     ></script>
     <noscript>
         <link rel="stylesheet" href="assets/css/noscript.css"/>

--- a/mate.html
+++ b/mate.html
@@ -1,14 +1,9 @@
 <title>botexpo</title>
 <html>
 <head>
-<script crossOrigin src="https://unpkg.com/react@16/umd/react.development.js"></script>
-<script crossOrigin src="https://unpkg.com/react-dom@16/umd/react-dom.development.js"></script>
-<script crossOrigin src="https://unpkg.com/@emotion/core@10/dist/core.umd.min.js"></script>
-<script crossOrigin src="https://unpkg.com/@emotion/styled@10/dist/styled.umd.min.js"></script>
-<script crossOrigin src="https://unpkg.com/emotion-theming@10/dist/emotion-theming.umd.min.js"></script>
 <script
         crossOrigin
-        src="https://unpkg.com/tock-react-kit@latest/build/tock-react-kit.umd.js"
+        src="https://unpkg.com/tock-react-kit@latest/build/tock-react-kit-standalone.umd.js"
 ></script>
 <style>
   body {

--- a/prod.html
+++ b/prod.html
@@ -1,14 +1,9 @@
 <title>botexpo</title>
 <html>
 <head>
-<script crossOrigin src="https://unpkg.com/react@16/umd/react.development.js"></script>
-<script crossOrigin src="https://unpkg.com/react-dom@16/umd/react-dom.development.js"></script>
-<script crossOrigin src="https://unpkg.com/@emotion/core@10/dist/core.umd.min.js"></script>
-<script crossOrigin src="https://unpkg.com/@emotion/styled@10/dist/styled.umd.min.js"></script>
-<script crossOrigin src="https://unpkg.com/emotion-theming@10/dist/emotion-theming.umd.min.js"></script>
 <script
         crossOrigin
-        src="https://unpkg.com/tock-react-kit@latest/build/tock-react-kit.umd.js"
+        src="https://unpkg.com/tock-react-kit@latest/build/tock-react-kit-standalone.umd.js"
 ></script>
 <style>
   body {


### PR DESCRIPTION
Currently the bot no longer works on the demo site. This PR adds the new version standalone of tock-react-kit in order to put it back into operation.